### PR TITLE
Adding support to Http Methods: GET, POST, PUT and DELETE

### DIFF
--- a/src/main/restql/core/async_request_builder.clj
+++ b/src/main/restql/core/async_request_builder.clj
@@ -206,6 +206,7 @@
        :metadata     (meta query-item-data)
        :resource     (:from query-item-data)
        :query-params (build-query-params query-item-data url resolved-query-item)
+       :http-method  (:method query-item-data)
        :timeout      timeout
        :headers      (:with-headers query-item-data)
        :post-body    (some-> query-item-data

--- a/src/main/restql/core/validator/core.clj
+++ b/src/main/restql/core/validator/core.clj
@@ -11,7 +11,7 @@
 
 (defn invalid-data-key [key]
   (not
-    (#{:from :with :with-headers :with-body :timeout :select} key)))
+    (#{:from :method :with :with-headers :with-body :timeout :select} key)))
 
 (defn keyword-or-vector? [value]
   (or

--- a/src/main/restql/parser/producer.clj
+++ b/src/main/restql/parser/producer.clj
@@ -34,6 +34,7 @@
 
 (defn produce-query-item [query-clauses]
   (let [resource          (->> query-clauses (find-first :FromResource) produce)
+        method            (->> query-clauses (find-first :HttpMethod) produce)
         alias-rule        (->> query-clauses (find-first :ResultAlias))
         alias             (if (nil? alias-rule) resource (produce alias-rule))
         header-rule       (->> query-clauses (find-first :HeaderRule) produce)
@@ -46,7 +47,7 @@
         ]
     (str alias
          flags-rule
-         " {:from " resource header-rule timeout-rule with-rule with-body-rule only-rule hide-rule "}")))
+         " {:from " resource header-rule timeout-rule with-rule with-body-rule only-rule hide-rule " :method " method "}")))
 
 (defn produce-header-rule [content]
   (let [produced-header-items (map produce content)]
@@ -218,6 +219,12 @@
       :QueryItem                   (produce-query-item content)
 
       :FromResource                (join-chars ":" content)
+      
+      ; Keeping from for "get" default for backwards compatibility reasons
+      :HttpMethod                  (if 
+                                      (= "from" (join-chars "" content))
+                                      ":get"
+                                      (join-chars ":" content))
       :ResultAlias                 (join-chars ":" content)
 
       :HeaderRule                  (produce-header-rule content)

--- a/src/resources/grammar.ebnf
+++ b/src/resources/grammar.ebnf
@@ -21,7 +21,7 @@ QueryItem =
 
 
 <FromRule> =
-  KW_FROM WS FromResource (WS_MAND KW_AS WS_MAND ResultAlias)?;
+  HttpMethod WS_MAND FromResource (WS_MAND KW_AS WS_MAND ResultAlias)?;
 
 FromResource =
   Identifier;
@@ -165,8 +165,11 @@ IgnoreErrorsFlag =
 <KW_USE> =
   <"use">;
 
-<KW_FROM> =
-  <"from">;
+<KW_METHOD> =
+  ("from" | "get" | "post" | "put" | "delete");
+
+HttpMethod = 
+  KW_METHOD;
 
 <KW_AS> =
   <"as">;

--- a/test/unit/restql/core/async_request_builder_test.clj
+++ b/test/unit/restql/core/async_request_builder_test.clj
@@ -41,6 +41,7 @@
   (is (=
     [{:url "http://example/123"
       :query-params {:sku "111"  :offer "123111"}
+      :http-method :get
       :resource :example
       :metadata nil
       :timeout nil
@@ -50,15 +51,17 @@
       :resource :example
       :metadata nil
       :query-params {:sku "222" :offer "456222"}
+      :http-method :get
       :timeout nil
       :headers nil
-       :post-body nil}]
+      :post-body nil}]
     
     (build-requests "http://example/:id"
                     {:from :example
-                      :with {:id [:cart :lines :productId]
-                             :sku [:cart :lines :sku]
-                             :offer [:cart :offers :id]}}
+                     :with {:id [:cart :lines :productId]
+                            :sku [:cart :lines :sku]
+                            :offer [:cart :offers :id]}
+                     :method :get}
                     {}
                     state))))
 
@@ -66,6 +69,7 @@
   (is (=
         [{:url "http://example/123"
           :query-params {:name "ABC"}
+          :http-method :get
           :resource :example
           :metadata nil
           :timeout nil
@@ -75,6 +79,7 @@
           :resource :example
           :metadata nil
           :query-params {:name "DEF"}
+          :http-method :get
           :timeout nil
           :headers nil
           :post-body nil}]
@@ -82,7 +87,8 @@
         (build-requests "http://example/:id"
                         {:from :example
                          :with {:id ["123" "456"]
-                                :name ["ABC" "DEF"]}}
+                                :name ["ABC" "DEF"]}
+                         :method :get}
                         {}
                         state))))
 
@@ -94,12 +100,14 @@
 
     (get-multiple-entities {:from :blibs
                             :with {:product [:cart :lines :productId]
-                                   :sku     [:cart :lines :sku]}} state))))
+                                   :sku     [:cart :lines :sku]}
+                            :method :get} state))))
 
 (deftest create-request-with-headers-test
   (is (=
     {:url "http://localhost:9999"
      :query-params {:id "123"}
+     :http-method :get
      :resource :cart
      :metadata nil
      :timeout nil
@@ -109,7 +117,8 @@
     (build-request "http://localhost:9999" 
                    {:from :cart 
                     :with {:id "123"} 
-                    :with-headers {"tid" "aaaaaaaaaa"}} 
+                    :with-headers {"tid" "aaaaaaaaaa"}
+                    :method :get} 
                    {}
                    {:done []}))))
 
@@ -117,6 +126,7 @@
   (is (=
     {:url "http://localhost:9999"
      :query-params {:id "123"}
+     :http-method :get
      :metadata nil
      :resource :cart
      :timeout nil
@@ -125,7 +135,8 @@
     
     (build-request "http://localhost:9999" 
                    {:from :cart 
-                    :with {:id "123"}}
+                    :with {:id "123"}
+                    :method :get}
                    {}
                    {:done []}))))
 
@@ -195,6 +206,7 @@
   (is (=
     {:url "http://localhost:9999"
      :query-params {:id "123"}
+     :http-method :get
      :resource :cart
      :metadata nil
      :timeout 2000
@@ -202,7 +214,7 @@
      :post-body nil}
     
     (build-request "http://localhost:9999" 
-                   {:from :cart :timeout 2000 :with {:id "123"}}
+                   {:from :cart :timeout 2000 :with {:id "123"} :method :get}
                    {}
                    {:done []}))))
 
@@ -211,6 +223,7 @@
   (is (=
         {:url "http://localhost:9999"
          :query-params {:id "123"}
+         :http-method :get
          :resource :cart
          :metadata nil
          :timeout nil
@@ -220,7 +233,8 @@
         (build-request "http://localhost:9999"
                        {:from :cart
                         :with {:id "123"}
-                        :with-body {:jedi {:name "Luke Skywalker" :weaponId 1}}}
+                        :with-body {:jedi {:name "Luke Skywalker" :weaponId 1}}
+                        :method :get}
                        {}
                        {:done []}))))
 

--- a/test/unit/restql/parser/core_test.clj
+++ b/test/unit/restql/parser/core_test.clj
@@ -7,17 +7,29 @@
 
   (testing "Testing simple query"
     (is (= (parse-query "from heroes as hero")
-           [:hero {:from :heroes}])))
+           [:hero {:from :heroes :method :get}])))
 
   (testing "Testing simple query without alias"
     (is (= (parse-query "from heroes")
-           [:heroes {:from :heroes}])))
+           [:heroes {:from :heroes :method :get}])))
+
+  (testing "Testing get method"
+    (is (= (parse-query "get heroes")
+            [:heroes {:from :heroes :method :get}])))
+
+  (testing "Testing post method"
+    (is (= (parse-query "post heroes")
+            [:heroes {:from :heroes :method :post}])))
+
+  (testing "Testing put method"
+    (is (= (parse-query "put heroes")
+            [:heroes {:from :heroes :method :put}])))
 
   (testing "Testing simple query with-body json"
     (is (= (parse-query "from heroes
                                         body
                                           foo = \"bar\"")
-           [:heroes {:from :heroes :with-body {:foo "bar"}}])))
+           [:heroes {:from :heroes :with-body {:foo "bar"} :method :get}])))
 
   (testing "Testing simple query with-body complex json"
     (is (= (parse-query "from heroes
@@ -26,7 +38,7 @@
                                           bar = {
                                             baz: \"baz\"
                                           }")
-           [:heroes {:from :heroes :with-body {:foo "bar" :bar {:baz "baz"}}}])))
+           [:heroes {:from :heroes :with-body {:foo "bar" :bar {:baz "baz"}} :method :get}])))
 
   (testing "Testing simple query with-body complex json and chaining"
     (is (= (parse-query "from heroes
@@ -35,102 +47,102 @@
                                           bar = {
                                             baz: \"baz\"
                                           }")
-           [:heroes {:from :heroes :with-body {:id [:api :id] :bar {:baz "baz"}}}])))
+           [:heroes {:from :heroes :with-body {:id [:api :id] :bar {:baz "baz"}} :method :get}])))
 
   (testing "Testing simple query params a use clause"
     (is (= (parse-query "use cache-control = 900
                                       from heroes as hero")
-           ^{:cache-control 900} [:hero {:from :heroes}])))
+           ^{:cache-control 900} [:hero {:from :heroes :method :get}])))
 
   (testing "Testing simple query params ignore errors"
     (is (= (parse-query "from heroes as hero ignore-errors")
-           [:hero ^{:ignore-errors "ignore"} {:from :heroes}])))
+           [:hero ^{:ignore-errors "ignore"} {:from :heroes :method :get}])))
 
   (testing "Testing multiple query"
     (is (= (parse-query "from heroes as hero
                                       from monsters as monster")
-           [:hero {:from :heroes}
-            :monster {:from :monsters}])))
+           [:hero {:from :heroes :method :get}
+            :monster {:from :monsters :method :get}])))
 
   (testing "Testing query params one numeric parameter"
     (is (= (parse-query "from heroes as hero params id = 123")
-           [:hero {:from :heroes :with {:id 123}}])))
+           [:hero {:from :heroes :with {:id 123} :method :get}])))
 
   (testing "Testing query params one string parameter"
     (is (= (parse-query "from heroes as hero params id = \"123\"")
-           [:hero {:from :heroes :with {:id "123"}}])))
+           [:hero {:from :heroes :with {:id "123"} :method :get}])))
 
   (testing "Testing query params variable parameter"
     (is (= (parse-query "from heroes as hero params id = $id" :context {"id" "123"})
-           [:hero {:from :heroes :with {:id "123"}}])))
+           [:hero {:from :heroes :with {:id "123"} :method :get}])))
 
   (testing "Testing query params one null parameter"
     (is (= (parse-query "from heroes as hero params id = 123, spell = null")
-           [:hero {:from :heroes :with {:id 123 :spell nil}}])))
+           [:hero {:from :heroes :with {:id 123 :spell nil} :method :get}])))
 
   (testing "Testing query params one boolean parameter"
     (is (= (parse-query "from heroes as hero params magician = true")
-           [:hero {:from :heroes :with {:magician true}}])))
+           [:hero {:from :heroes :with {:magician true} :method :get}])))
 
   (testing "Testing query params one array parameter"
     (is (= (parse-query "from heroes as hero params class = [\"warrior\", \"magician\"]")
-           [:hero {:from :heroes :with {:class ["warrior" "magician"]}}])))
+           [:hero {:from :heroes :with {:class ["warrior" "magician"]} :method :get}])))
 
   (testing "Testing query params one complex parameter"
     (is (= (parse-query "from heroes as hero params equip = {sword: 1, shield: 2}")
-           [:hero {:from :heroes :with {:equip {:sword 1 :shield 2}}}])))
+           [:hero {:from :heroes :with {:equip {:sword 1 :shield 2}} :method :get}])))
 
   (testing "Testing query params one complex parameter params subitems"
     (is (= (parse-query "from heroes as hero params equip = {sword: {foo: \"bar\"}, shield: [1, 2, 3]}")
-           [:hero {:from :heroes :with {:equip {:sword {:foo "bar"} :shield [1 2 3]}}}])))
+           [:hero {:from :heroes :with {:equip {:sword {:foo "bar"} :shield [1 2 3]}} :method :get}])))
 
   (testing "Testing query params one chained parameter"
     (is (= (parse-query "from heroes as hero params id = player.id")
-           [:hero {:from :heroes :with {:id [:player :id]}}])))
+           [:hero {:from :heroes :with {:id [:player :id]} :method :get}])))
 
   (testing "Testing query params one chained parameter and metadata"
     (is (= (parse-query "from heroes as hero params id = player.id -> json")
-           [:hero {:from :heroes :with {:id ^{:encoder :json} [:player :id]}}])))
+           [:hero {:from :heroes :with {:id ^{:encoder :json} [:player :id]} :method :get}])))
 
   (testing "Testing query params one chained parameter and metadata"
     (is (= (pr-str (parse-query "from heroes as hero params id = player.id -> encoder(\"json\", \"pretty\")"))
-           (pr-str [:hero {:from :heroes :with {:id ^{:encoder :json :args ["pretty"]} [:player :id]}}]))))
+           (pr-str [:hero {:from :heroes :with {:id ^{:encoder :json :args ["pretty"]} [:player :id]} :method :get}]))))
 
   (testing "Testing query params headers"
     (is (= (parse-query "from heroes as hero headers Content-Type = \"application/json\" params id = 123")
-           [:hero {:from :heroes :with-headers {"Content-Type" "application/json"} :with {:id 123}}])))
+           [:hero {:from :heroes :with-headers {"Content-Type" "application/json"} :with {:id 123} :method :get}])))
 
   (testing "Testing query params headers and parameters"
     (is (= (parse-query "from heroes as hero headers Authorization = $auth params id = 123" :context {"auth" "abc123"})
-           [:hero {:from :heroes :with-headers {"Authorization" "abc123"} :with {:id 123}}])))
+           [:hero {:from :heroes :with-headers {"Authorization" "abc123"} :with {:id 123} :method :get}])))
 
   (testing "Testing query params hidden selection"
     (is (= (parse-query "from heroes as hero params id = 1 hidden")
-           [:hero {:from :heroes :with {:id 1} :select :none}])))
+           [:hero {:from :heroes :with {:id 1} :select :none :method :get}])))
 
   (testing "Testing query params only selection"
     (is (= (parse-query "from heroes as hero params id = 1 only id, name")
-           [:hero {:from :heroes :with {:id 1} :select #{:id :name}}])))
+           [:hero {:from :heroes :with {:id 1} :select #{:id :name} :method :get}])))
 
   (testing "Testing query params only selection of inner elements"
     (is (= (parse-query "from heroes as hero params id = 1 only skills.id, skills.name, name")
-           [:hero {:from :heroes :with {:id 1} :select #{:name [:skills #{:id :name}]}}])))
+           [:hero {:from :heroes :with {:id 1} :select #{:name [:skills #{:id :name}]} :method :get}])))
 
   (testing "Testing query params paramater params dot and chaining"
     (is (= (parse-query "from heroes as hero params weapon.id = weapon.id")
-           [:hero {:from :heroes :with {:weapon.id [:weapon :id]}}])))
+           [:hero {:from :heroes :with {:weapon.id [:weapon :id]} :method :get}])))
 
   (testing "Testing query params only selection and a filter"
     (is (= (parse-query "from heroes as hero params id = 1 only id, name -> matches(\"foo\")")
-           [:hero {:from :heroes :with {:id 1} :select #{:id [:name {:matches "foo"}]}}])))
+           [:hero {:from :heroes :with {:id 1} :select #{:id [:name {:matches "foo"}]} :method :get}])))
 
   (testing "Testing query params only selection and a filter params wildcard"
     (is (= (parse-query "from heroes as hero params id = 1 only id -> equals(1), *")
-           [:hero {:from :heroes :with {:id 1} :select #{[:id {:equals 1}] :*}}])))
+           [:hero {:from :heroes :with {:id 1} :select #{[:id {:equals 1}] :*} :method :get}])))
 
   (testing "Testing filter with variable"
     (is (= (parse-query "from heroes as hero params id = 1 only id, name -> matches($name)" :context {"name" "Hero"})
-           [:hero {:from :heroes :with {:id 1} :select #{:id [:name {:matches "Hero"}]}}])))
+           [:hero {:from :heroes :with {:id 1} :select #{:id [:name {:matches "Hero"}]} :method :get}])))
 
   (testing "Testing full featured query"
     (binding [*print-meta* true]
@@ -147,5 +159,6 @@
                                  :with         {:limit  ^{:expand false :encoder :json}
                                                         [:product :id]
                                                 :fields ["rating" "tags" "images" "groups"]}
-                                 :select       #{:id :name :cep :phone}}]))))))
+                                 :select       #{:id :name :cep :phone}
+                                 :method :get}]))))))
 


### PR DESCRIPTION
I've added transparent language support to POST, PUT and DELETE.

Sample queries:

```resql
get user_get
   with name = "test_user"

post user_post
  body user = {name: "new_user"}

put user_put
  body user = {name: user_get.name, newName: "updated_user"}

delete user_delete
  with user = [{name: "new_user"}, {name: "updated_user"}] -> flatten
```

The request handler will inject the request body only into POST and PUT requests. It also works with no request body (although it doesn't make sense for most cases).

The `from` syntax was maintained for compatibility reasons and falls back to the new `get` syntax.